### PR TITLE
Use a map to implement litToArrayPreimage

### DIFF
--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -757,7 +757,7 @@ litToArrayPreimage val =
       -- We have found an 'foundImageHashKey' such that 'foundImageHashKey <= val'.
       -- Now we must check if 'val' is also within the 256-byte range starting at 'foundImageHashKey',
       -- i.e., 'val <= foundImageHashKey + 255'.
-      if val <= image_upper_bound then
+      if val <= foundImageHashKey + 255 then
         Just (array_id, val - foundImageHashKey) -- Return the id and the offset from the hash
       else
         -- 'val' is greater than the upper bound for 'foundImageHashKey'.

--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -1649,11 +1649,13 @@ containsNode p = getAny . foldExpr go (Any False)
 inRange :: Int -> Expr EWord -> Prop
 inRange sz e = PAnd (PGEq e (Lit 0)) (PLEq e (Lit $ 2 ^ sz - 1))
 
+-- | images of keccak(bytes32(x)) where 0 <= x < 256
+preImages :: [(W256, Word8)]
+preImages = [(keccak' (word256Bytes . into $ i), i) | i <- [0..255]]
 
 -- | images of keccak(bytes32(x)) where 0 <= x < 256
 preImageLookupMap :: Map.Map W256 (Word8, W256)
-preImageLookupMap = Map.fromList $ map (\(imageHash, originalId) -> (imageHash, (originalId, imageHash + fromInteger 255))) preImagesSource
-  where preImagesSource = [(keccak' (word256Bytes . into $ i), i) | i <- [0..255]]
+preImageLookupMap = Map.fromList $ map (\(imageHash, originalId) -> (imageHash, (originalId, imageHash + fromInteger 255))) preImages
 data ConstState = ConstState
   { values :: Map.Map (Expr EWord) W256
   , canBeSat :: Bool


### PR DESCRIPTION
## Description

In certain runs, litToArrayPreimage was taking most of the time executing so this is an optimized version of it using maps

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
